### PR TITLE
Leverage sqlparser-rs for query parsing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "sqlparser",
  "sqlx",
  "tokio",
  "url",
@@ -1994,6 +1995,15 @@ dependencies = [
  "itertools",
  "nom",
  "unicode_categories",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95c4bae5aba7cd30bd506f7140026ade63cff5afd778af8854026f9606bf5d4"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ sqlx = { version = "0.7.3", features = [
 tokio = "1.29.1"
 url = "2.4.0"
 postgres-types = "0.2.5"
+sqlparser = "0.43.1"
 
 
 [dev-dependencies]


### PR DESCRIPTION
`cargo add sqlparser` to introduce improved check and error response for validity of query input.

Example using invalid query "test": 

```
pg_later=# select pglater.exec('select * from pg_available_extensions order by name limit 2') as job_id;
 
job_id
--------
      1
(1 row)

pg_later=# select pglater.exec('test') as job_id;
ERROR:  Query parsing failed, please submit a valid query: ParserError("Expected an SQL statement, found: test at Line: 1, Column 1")
```